### PR TITLE
🧹 Add missing type annotations in Bloc event handler and widget

### DIFF
--- a/lib/src/console_view/view/console/bloc/console_bloc.dart
+++ b/lib/src/console_view/view/console/bloc/console_bloc.dart
@@ -39,7 +39,7 @@ class ConsoleBloc extends Bloc<ConsoleEvent, ConsoleState> {
   }) : _messageRepository = messageRepository,
        _loggerCacheRepository = loggerCacheRepository,
        super(const ConsoleInitial(selectedLogType: LogType.debug)) {
-    on<ConsoleEvent>((event, emit) async {
+    on<ConsoleEvent>((ConsoleEvent event, Emitter<ConsoleState> emit) async {
       switch (event) {
         case ConsoleClear():
           emit(ConsoleLoading(selectedLogType: _selectedType));

--- a/lib/src/console_view/view/widgets/text_values_dropdown_widget.dart
+++ b/lib/src/console_view/view/widgets/text_values_dropdown_widget.dart
@@ -29,7 +29,7 @@ class TextValuesDropdownWidget extends StatelessWidget {
                     DropdownMenuItem<String>(value: value, child: Text(value)),
               )
               .toList(),
-          onChanged: (value) {
+          onChanged: (String? value) {
             if (value != null) onChanged(value);
           },
         ),


### PR DESCRIPTION
🎯 **What:** Added missing type annotations to lambda parameters in `ConsoleBloc` and `TextValuesDropdownWidget`.
💡 **Why:** Improves code maintainability, readability, and satisfies the project's strict inference rules, resolving `inference_failure_on_untyped_parameter` linting warnings.
✅ **Verification:** Confirmed via `dart analyze` that the specific linting warnings are resolved for the modified files.
✨ **Result:** Cleaner code with explicit type safety in event handlers and callbacks.

---
*PR created automatically by Jules for task [12152945002387668861](https://jules.google.com/task/12152945002387668861) started by @saulogatti*