### PR TITLE
✨ Update analysis options and refactor log file path handling

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,8 @@
 include: package:lints/recommended.yaml
 
+formatter: 
+  page_width: 110
+
 analyzer:
   errors:
     dead_code: warning

--- a/lib/src/data/cache/logger_cache.dart
+++ b/lib/src/data/cache/logger_cache.dart
@@ -34,8 +34,7 @@ final class LoggerCache {
   ///
   /// [directory]: o diretório base onde os logs serão armazenados.
   LoggerCache(String directory, {IFileManagerType? fileManagerType})
-    : _fileManagerType =
-          fileManagerType ?? FileManager(fileType: FileType.json) {
+    : _fileManagerType = fileManagerType ?? FileManager(fileType: FileType.json) {
     _future = Completer<void>();
     _init(directory);
   }
@@ -65,10 +64,7 @@ final class LoggerCache {
     await _fileManagerType.deleteFile(fileName);
   }
 
-  Future<(List<int>?, String?)> exportLogs(
-    List<LoggerObjectBase> logs,
-    ExportFormat format,
-  ) async {
+  Future<(List<int>?, String?)> exportLogs(List<LoggerObjectBase> logs, ExportFormat format) async {
     await writeLogToFile("share.json", logs);
     final pathFile = _getPathFile("share.json");
     final objEncode = jsonEncode(logs);
@@ -90,11 +86,7 @@ final class LoggerCache {
       await futureInitialization.future;
       final directory = Directory(_directoryPath);
       if (await directory.exists()) {
-        final files = await directory
-            .list()
-            .where((entity) => entity is File)
-            .cast<File>()
-            .toList();
+        final files = await directory.list().where((entity) => entity is File).cast<File>().toList();
         final Map<EnumLoggerType, LoggerJsonList?> allLogs = {};
         for (final file in files) {
           if (file.path.endsWith('.json')) {
@@ -165,11 +157,11 @@ final class LoggerCache {
   ///
   /// Completa [futureInitialization] após criar (ou validar) o diretório.
   Future<void> _init(String directory) async {
+    assert(directory.isNotEmpty, 'O diretório base para os logs não pode ser vazio');
+    if (directory.endsWith('/')) {
+      throw AssertionError('O diretório base para os logs deve terminar com /');
+    }
     try {
-      assert(
-        directory.isNotEmpty,
-        'O diretório base para os logs não pode ser vazio',
-      );
       final directoryPath = Directory('$directory/loggerApp/logs');
       if (!await directoryPath.exists()) {
         await directoryPath.create(recursive: true);

--- a/lib/src/data/cache/logger_cache_repository_impl.dart
+++ b/lib/src/data/cache/logger_cache_repository_impl.dart
@@ -10,7 +10,7 @@ import 'package:log_custom_printer/src/domain/logs_object/logger_object.dart';
 /// e opcionalmente em arquivo.
 ///
 /// Mantém os logs organizados por tipo em memória usando [LoggerJsonList].
-/// Se um [saveLogFilePath] for fornecido, também persiste os logs em disco
+/// Se um [directoryToSave] for fornecido, também persiste os logs em disco
 /// através da classe [LoggerCache].
 ///
 /// {@category Utilities}
@@ -19,7 +19,7 @@ final class LoggerCacheRepositoryImpl implements ILoggerCacheRepository {
   final int maxLogEntries;
 
   /// Caminho base para salvar os arquivos de log (opcional).
-  final String? saveLogFilePath;
+  final String? directoryToSave;
 
   /// Gerenciador de persistência em arquivo.
   LoggerCache? _loggerCache;
@@ -33,16 +33,16 @@ final class LoggerCacheRepositoryImpl implements ILoggerCacheRepository {
   /// Cria uma nova instância da implementação de cache.
   ///
   /// [maxLogEntries]: limite de logs mantidos em memória por tipo (padrão: 1000).
-  /// [saveLogFilePath]: diretório base para persistência (se omitido, não salva em disco).
+  /// [directoryToSave]: diretório base para persistência (se omitido, não salva em disco).
   /// [fileType]: tipo de arquivo para persistência (padrão: [FileType.json]).
   LoggerCacheRepositoryImpl({
     this.maxLogEntries = 1000,
-    this.saveLogFilePath,
+    this.directoryToSave,
     FileType fileType = FileType.json,
   }) {
-    if (saveLogFilePath != null) {
+    if (directoryToSave != null) {
       _loggerCache = LoggerCache(
-        saveLogFilePath!,
+        directoryToSave!,
         fileManagerType: FileManager(fileType: fileType),
       );
       _futureInitialization = _initialize();

--- a/lib/src/log_printer_locator.dart
+++ b/lib/src/log_printer_locator.dart
@@ -102,7 +102,7 @@ LoggerPersistenceService registerLogPrinterColor({
     const LogWithColorPrint(),
     cacheRepository: LoggerCacheRepositoryImpl(
       maxLogEntries: maxLogsInCache,
-      saveLogFilePath: cacheFilePath,
+      directoryToSave: cacheFilePath,
       fileType: fileType,
     ),
     config: config ?? const ConfigLog(),
@@ -137,7 +137,7 @@ LoggerPersistenceService registerLogPrinterSimple({
     const LogSimplePrint(),
     cacheRepository: LoggerCacheRepositoryImpl(
       maxLogEntries: maxLogsInCache,
-      saveLogFilePath: cacheFilePath,
+      directoryToSave: cacheFilePath,
       fileType: fileType,
     ),
     config: config ?? const ConfigLog(),


### PR DESCRIPTION
- Added a formatter configuration to `analysis_options.yaml` to set the page width to 110.
- Refactored `LoggerCacheRepositoryImpl` and related classes to replace `saveLogFilePath` with `directoryToSave` for clarity and consistency in naming.
- Updated documentation comments to reflect the new parameter name and its purpose.

This commit enhances code readability and maintains consistency across the logging implementation.