### PR TITLE
docs: Atualizar instruções do Copilot e documentação de API

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,8 @@
 
 ## Code Style
 - Siga `analysis_options.yaml` e `Effective Dart`.
-- Preserve API pública estável em `lib/log_custom_printer.dart` (exports são parte do contrato).
+- Preserve API pública estável em `lib/log_custom_printer.dart`; qualquer mudança nos `export`s é mudança de contrato.
+- Só adicione um novo `export` em `lib/log_custom_printer.dart` quando o tipo realmente fizer parte da API pública; caso contrário, mantenha-o interno em `lib/src/`.
 - Não editar arquivos gerados (`*.g.dart`).
 
 ## Architecture
@@ -17,8 +18,12 @@
   - integração recomendada em classes de uso via `LoggerClassMixin`.
 
 ## Build and Test
-- Dependências: `dart pub get` (ou `flutter pub get`).
-- Testes: `dart test` (pacote Dart) e `flutter test` quando necessário.
+- Este pacote é **Dart puro**; use `dart pub get`, `dart analyze` e `dart test` por padrão.
+- Não use comandos Flutter neste repositório, exceto ao documentar integração em apps consumidores.
+- Testes:
+  - suíte completa: `dart test`
+  - ficheiro único: `dart test test\logger_json_list_test.dart`
+  - teste único por nome: `dart test test\logger_json_list_test.dart -n "keeps the newest entries first and trims when capacity is exceeded"`
 - Análise estática: `dart analyze`.
 - Geração de código (obrigatória após mudanças em `@JsonSerializable`):
   - `dart run build_runner build --delete-conflicting-outputs`
@@ -35,13 +40,14 @@
   6) rodar `build_runner`.
 - Evite `print` solto fora das estratégias de impressão da biblioteca.
 - Em testes que tocam DI/logging, registre impressora no `setUp` e faça `GetIt.instance.reset()` no `tearDown`.
+- Em testes que tocam cache/ficheiros, prefira `Directory.systemTemp.createTemp(...)` ou diretórios temporários dedicados e remova-os no `tearDown`/`tearDownAll`.
 
 ## Reference Docs (link, don’t embed)
 - Visão geral e setup: `README.md`, histórico: `CHANGELOG.md`
-- Núcleo e DI: `docs/Core.md`
-- Tipos de log: `docs/LogTypes.md`
-- Estratégias de impressão: `docs/Printers.md`
-- Configuração/filtros: `docs/Configuration.md`
-- Utilitários e cache: `docs/Utilities.md`
-- Documentação expandida: `docs/DOCUMENTATION.md`
-- Migração consola Flutter (pacote à parte): `docs/ConsoleView.md`
+- Núcleo e DI: `doc/Core.md`
+- Tipos de log: `doc/LogTypes.md`
+- Estratégias de impressão: `doc/Printers.md`
+- Configuração/filtros: `doc/Configuration.md`
+- Utilitários e cache: `doc/Utilities.md`
+- Documentação expandida: `doc/DOCUMENTATION.md`
+- Migração consola Flutter (pacote à parte): `doc/ConsoleView.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,8 +22,7 @@
 - Não use comandos Flutter neste repositório, exceto ao documentar integração em apps consumidores.
 - Testes:
   - suíte completa: `dart test`
-  - ficheiro único: `dart test test\logger_json_list_test.dart`
-  - teste único por nome: `dart test test\logger_json_list_test.dart -n "keeps the newest entries first and trims when capacity is exceeded"`
+  - ficheiro único: `dart test test/logger_json_list_test.dart`\n  - teste único por nome: `dart test test/logger_json_list_test.dart -n "keeps the newest entries first and trims when capacity is exceeded"`
 - Análise estática: `dart analyze`.
 - Geração de código (obrigatória após mudanças em `@JsonSerializable`):
   - `dart run build_runner build --delete-conflicting-outputs`

--- a/lib/src/data/cache/logger_cache.dart
+++ b/lib/src/data/cache/logger_cache.dart
@@ -66,6 +66,10 @@ final class LoggerCache {
     await _fileManagerType.deleteFile(fileName);
   }
 
+  /// Exporta uma lista de logs para um arquivo e retorna os dados em bytes e o caminho do arquivo.
+  ///
+  /// [logs]: lista de objetos de log para exportar.
+  /// [format]: formato de exportação desejado.
   Future<(List<int>?, String?)> exportLogs(List<LoggerObjectBase> logs, ExportFormat format) async {
     await writeLogToFile("share.json", logs);
     final pathFile = _getPathFile("share.json");
@@ -74,6 +78,7 @@ final class LoggerCache {
     return (objEncode.codeUnits, pathFile);
   }
 
+  /// Retorna o caminho completo de um arquivo de log para fins de teste.
   @visibleForTesting
   String getPathFileForTest(String fileName) {
     return _getPathFile(fileName);

--- a/lib/src/data/cache/logger_cache_repository_impl.dart
+++ b/lib/src/data/cache/logger_cache_repository_impl.dart
@@ -107,6 +107,9 @@ final class LoggerCacheRepositoryImpl implements ILoggerCacheRepository {
     return [];
   }
 
+  /// Importa logs de uma string no formato especificado.
+  ///
+  /// Atualmente não implementado.
   @override
   Future<void> importLogs(String content, ExportFormat format) {
     throw UnimplementedError();

--- a/lib/src/data/cache/logger_persistence_service.dart
+++ b/lib/src/data/cache/logger_persistence_service.dart
@@ -23,8 +23,10 @@ final class LoggerPersistenceService {
   /// Recebe a lista de logs atual após operações de escrita/limpeza.
   void Function(List<LoggerObjectBase>)? logOutputHandler;
 
+  /// Mecanismo de filtragem de logs.
   final LogFilterEngine _filterEngine;
 
+  /// Mecanismo de ordenação de logs.
   final LogSortEngine _sortEngine;
 
   /// Cria o serviço com um [cacheRepository] customizado.

--- a/lib/src/domain/log_helpers/logger_enum.dart
+++ b/lib/src/domain/log_helpers/logger_enum.dart
@@ -8,6 +8,13 @@ import 'enum_logger_type.dart';
 ///
 /// {@category Utilities}
 extension LoggerEnum on LoggerObjectBase {
+  /// Retorna o [EnumLoggerType] correspondente ao tipo concreto desta instância.
+  ///
+  /// Mapeia:
+  /// - [ErrorLog] → [EnumLoggerType.error]
+  /// - [WarningLog] → [EnumLoggerType.warning]
+  /// - [InfoLog] → [EnumLoggerType.info]
+  /// - Outros ([DebugLog]) → [EnumLoggerType.debug]
   EnumLoggerType get enumLoggerType {
     if (this is ErrorLog) return EnumLoggerType.error;
     if (this is WarningLog) return EnumLoggerType.warning;

--- a/lib/src/domain/query/logger_filter.dart
+++ b/lib/src/domain/query/logger_filter.dart
@@ -9,6 +9,8 @@ import 'package:log_custom_printer/src/domain/query/log_sort_engine.dart';
 /// Delega ao engine apropriado conforme os critérios presentes na query:
 /// - Se [LogQuery.types] não estiver vazio, aplica filtragem por tipo.
 /// - Caso contrário, aplica ordenação conforme [LogQuery.sortDirection].
+///
+/// {@category Query}
 class LoggerFilter {
   /// Query com os critérios de filtragem e/ou ordenação.
   LogQuery query;
@@ -19,7 +21,11 @@ class LoggerFilter {
   /// Aplica filtragem e/ou ordenação a [logs] conforme a [query].
   ///
   /// Retorna os [logs] sem modificação se nenhum critério estiver definido.
+  ///
+  /// Observação: Atualmente, se [LogQuery.types] estiver presente, apenas a
+  /// filtragem é aplicada. Caso contrário, a ordenação é aplicada.
   List<LoggerObjectBase> apply(List<LoggerObjectBase> logs) {
+
     if (query.types != null && query.types!.isNotEmpty) {
       return const LogFilterEngine().apply(logs, query);
     } else if (query.sortDirection == SortDirection.asc) {

--- a/lib/src/extensions/date_time_log_helper.dart
+++ b/lib/src/extensions/date_time_log_helper.dart
@@ -19,6 +19,10 @@ extension DateTimeLoggingExtensions on DateTime {
   /// "dd/MM/yyyy HH:mm:ss.SSS", ideal para timestamps de log.
   String get logFullDateTime => '${onlyDate()} ${onlyTime()}';
 
+  /// Cria uma cópia deste DateTime com componentes de tempo alterados.
+  ///
+  /// [hour], [minute] e [second] permitem sobrescrever partes específicas do
+  /// horário. Mantém os mesmos valores de ano, mês e dia da instância original.
   DateTime copyWithTime({int? hour, int? minute, int? second}) {
     return DateTime(
       year,
@@ -54,10 +58,12 @@ extension DateTimeLoggingExtensions on DateTime {
     return '$h:$min:$sec.$ms';
   }
 
+  /// Formata um número com 3 dígitos (preenche com zeros à esquerda).
   String threeDigits(int n) {
     return n.toString().padLeft(3, '0');
   }
 
+  /// Formata um número com 2 dígitos (preenche com zeros à esquerda).
   String twoDigits(int n) {
     return n.toString().padLeft(2, '0');
   }


### PR DESCRIPTION
## Resumo
- atualiza `.github/copilot-instructions.md` com orientações mais precisas para este pacote Dart puro
- corrige referências de documentação de `docs/` para `doc/`
- amplia comentários de API em classes e extensões do pacote

## Motivação
- reduzir atrito em sessões futuras do Copilot com comandos, caminhos e convenções incorretas
- melhorar a documentação embutida da API para manutenção e geração de `dart doc`

## Como testar
- Não aplicável; mudanças de documentação e comentários de API

## Checklist
- [x] documentação atualizada
- [x] sem artefatos gerados incluídos
